### PR TITLE
Refactor CMAModelParams: Fix mutable defaults and enable strict assignment validation

### DIFF
--- a/pfun_cma_model/engine/bounds.py
+++ b/pfun_cma_model/engine/bounds.py
@@ -50,19 +50,6 @@ def serialize_bounds(bounds: "Bounds") -> Dict[str, Any]:
     return bounds.__json__()
 
 
-class BoundsType:
-
-    def __get_pydantic_core_schema__(
-        self,
-        source: Type[Any],
-        handler: GetCoreSchemaHandler,
-    ) -> core_schema.CoreSchema:  # type: ignore
-        # This is a Pydantic v2 custom type, it should return a CoreSchema
-        # The type hint for GetCoreSchemaHandler.return_type is core_schema.CoreSchema
-        # The error "Return type "core_schema.CoreSchema" of "__get_pydantic_core_schema__" incompatible with return type "Any" in supertype "object"" is incorrect.
-        return _BOUNDS_SCHEMA
-
-
 class Bounds:
     """Bounds constraint on the variables.
 

--- a/pfun_cma_model/engine/cma_model_params.py
+++ b/pfun_cma_model/engine/cma_model_params.py
@@ -149,7 +149,7 @@ class CMAModelParams(BaseModel):
         eps (float, optional): Random noise scale ("epsilon"). Defaults to 1e-18.
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, validate_assignment=True)
 
     """
     Time vector (decimal hours). Optional.
@@ -182,7 +182,9 @@ class CMAModelParams(BaseModel):
     """
     Solar noon offset (latitude). Defaults to 0.0.
     """
-    tM: Any | Annotated[ndarray, NumpyArray] | float = array([7.0, 11.0, 17.5])
+    tM: Any | Annotated[ndarray, NumpyArray] | float = Field(
+        default_factory=lambda: array([7.0, 11.0, 17.5])
+    )
     """
     Meal times (hours). Defaults to (7.0, 11.0, 17.5).
     """
@@ -237,11 +239,6 @@ class CMAModelParams(BaseModel):
                 setattr(self, key, value)
             elif hasattr(self, key):
                 setattr(self, key, value)
-            elif key.startswith("tM"):
-                tM_array = self.tM if len(self.tM) > 0 else []
-                tM_array = list(self.tM)
-                tM_array.append(float(value))
-                setattr(self, "tM", tM_array)  # append new values to tM
 
     @field_serializer("taug", "tM", check_fields=False)
     def serialize_ndarrays(self, value, *args):

--- a/tests/test_cma_sleepwake.py
+++ b/tests/test_cma_sleepwake.py
@@ -23,6 +23,7 @@ class TestCMASleepWakeModel:
     def test_update_with_invalid_parameters(self):
         from pfun_cma_model.engine.bounds import Bounds, BoundsTypeError
         from pfun_cma_model.engine.cma import CMASleepWakeModel
+        from pydantic import ValidationError
 
         # Create an instance of CMASleepWakeModel
         model = CMASleepWakeModel()
@@ -37,7 +38,7 @@ class TestCMASleepWakeModel:
                 toff="invalid",
             )
         except Exception as e:
-            assert isinstance(e, (BoundsTypeError, ValueError, TypeError))
+            assert isinstance(e, (BoundsTypeError, ValueError, TypeError, ValidationError))
 
     def test_integrate_G_with_NaN_values(self):
         from pfun_cma_model.engine.bounds import Bounds, BoundsTypeError


### PR DESCRIPTION
This PR addresses code quality issues identified during review. It fixes a mutable default argument in `CMAModelParams` by using `default_factory`, enabling proper instance isolation. It also enforces stricter type validation by enabling `validate_assignment` in the Pydantic model. Dead code (`BoundsType`) was removed, and `CMAModelParams.update` was cleaned up. Tests were updated to reflect the new validation behavior.

---
*PR created automatically by Jules for task [12176571174377010755](https://jules.google.com/task/12176571174377010755) started by @rocapp*