### PR TITLE
Add PyQt6 frontend for PFun Health Tips Demo

### DIFF
--- a/packages/pfun_qt_gui/README.md
+++ b/packages/pfun_qt_gui/README.md
@@ -1,0 +1,3 @@
+# PFun Qt GUI
+
+A PyQt6 frontend interface for generating and interacting with the PFun Health Tips Demo.

--- a/packages/pfun_qt_gui/pyproject.toml
+++ b/packages/pfun_qt_gui/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "pfun-qt-gui"
+version = "0.1.0"
+description = "A PyQt6 frontend for the PFun CMA Model."
+readme = "README.md"
+authors = [
+    { name = "Robbie Capps", email = "robbie@pfun.me" }
+]
+requires-python = "==3.12.11"
+dependencies = [
+    "PyQt6>=6.6.0",
+    "pfun-common"
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/packages/pfun_qt_gui/src/pfun_qt_gui/__init__.py
+++ b/packages/pfun_qt_gui/src/pfun_qt_gui/__init__.py
@@ -1,0 +1,1 @@
+"""pfun_qt_gui package init"""

--- a/packages/pfun_qt_gui/src/pfun_qt_gui/main.py
+++ b/packages/pfun_qt_gui/src/pfun_qt_gui/main.py
@@ -1,0 +1,186 @@
+import sys
+import os
+import json
+from PyQt6.QtWidgets import (
+    QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
+    QLabel, QTextEdit, QPushButton, QTextBrowser, QMessageBox, QSplitter
+)
+from PyQt6.QtCore import Qt, QUrl, QUrlQuery
+from PyQt6.QtNetwork import QNetworkAccessManager, QNetworkRequest, QNetworkReply
+
+class PFunHealthTipsDemo(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("PFun Health Tips Demo")
+        self.setMinimumSize(800, 600)
+
+        self.api_url = os.environ.get("PFUN_QT_GUI_API_URL", "http://127.0.0.1:8001")
+        self.network_manager = QNetworkAccessManager(self)
+        self.network_manager.finished.connect(self.on_request_finished)
+
+        self.init_ui()
+
+    def init_ui(self):
+        # Main widget and layout
+        main_widget = QWidget()
+        main_layout = QVBoxLayout(main_widget)
+
+        # Header
+        title_label = QLabel("PFun Health Tips Demo")
+        title_label.setStyleSheet("font-size: 24px; font-weight: bold;")
+
+        subtitle_label = QLabel("Generate personalized health tips")
+        subtitle_label.setStyleSheet("font-size: 14px; color: gray;")
+
+        main_layout.addWidget(title_label)
+        main_layout.addWidget(subtitle_label)
+        main_layout.addSpacing(10)
+
+        # Input Section
+        input_instruction = QLabel("Please enter a query to generate personalized health tips.\nThe demo will generate a random health scenario if the input is left blank.")
+        input_instruction.setStyleSheet("color: #0056b3;")
+        main_layout.addWidget(input_instruction)
+
+        self.query_input = QTextEdit()
+        self.query_input.setPlaceholderText("Example: I'm a relatively healthy individual who exercises most mornings before sunrise. What tips do you have for me?")
+        self.query_input.setFixedHeight(120)
+        main_layout.addWidget(self.query_input)
+
+        # Submit Button
+        self.submit_btn = QPushButton("Submit")
+        self.submit_btn.setStyleSheet("background-color: #0d6efd; color: white; font-size: 16px; padding: 10px; border-radius: 5px;")
+        self.submit_btn.clicked.connect(self.on_submit)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addWidget(self.submit_btn)
+        btn_layout.addStretch()
+        main_layout.addLayout(btn_layout)
+        main_layout.addSpacing(20)
+
+        # Output Section Header
+        output_title = QLabel("Output")
+        output_title.setStyleSheet("font-size: 20px; font-weight: bold;")
+        output_subtitle = QLabel("PFun generated information")
+        output_subtitle.setStyleSheet("font-size: 12px; color: gray;")
+
+        main_layout.addWidget(output_title)
+        main_layout.addWidget(output_subtitle)
+
+        # Splitter for outputs
+        self.splitter = QSplitter(Qt.Orientation.Horizontal)
+
+        # Recommendations area
+        recs_widget = QWidget()
+        recs_layout = QVBoxLayout(recs_widget)
+        recs_layout.setContentsMargins(0, 0, 5, 0)
+        recs_header = QLabel("Recommendations")
+        recs_header.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        recs_header.setStyleSheet("background-color: #0d6efd; color: white; font-weight: bold; padding: 5px; border-radius: 3px;")
+        self.recs_output = QTextBrowser()
+        self.recs_output.setOpenExternalLinks(True)
+        recs_layout.addWidget(recs_header)
+        recs_layout.addWidget(self.recs_output)
+
+        # Raw Output area
+        raw_widget = QWidget()
+        raw_layout = QVBoxLayout(raw_widget)
+        raw_layout.setContentsMargins(5, 0, 0, 0)
+        raw_header = QLabel("Raw output")
+        raw_header.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        raw_header.setStyleSheet("background-color: #0dcaf0; color: black; font-weight: bold; padding: 5px; border-radius: 3px;")
+        self.raw_output = QTextBrowser()
+        self.raw_output.setStyleSheet("background-color: #f8f9fa; font-family: monospace;")
+        raw_layout.addWidget(raw_header)
+        raw_layout.addWidget(self.raw_output)
+
+        self.splitter.addWidget(recs_widget)
+        self.splitter.addWidget(raw_widget)
+        self.splitter.setSizes([400, 400])
+
+        main_layout.addWidget(self.splitter)
+
+        self.setCentralWidget(main_widget)
+
+    def on_submit(self):
+        query = self.query_input.toPlainText()
+
+        # Disable button and update text
+        self.submit_btn.setEnabled(False)
+        self.submit_btn.setText("Loading...")
+
+        # Clear previous outputs
+        self.recs_output.clear()
+        self.raw_output.clear()
+
+        # Build URL with query parameter
+        url_str = f"{self.api_url}/llm/generate-scenario"
+        url = QUrl(url_str)
+        # We need to send as a POST request (even with empty body, but query in params if needed)
+        query_params = QUrlQuery()
+        query_params.addQueryItem("prompt", query)
+        url.setQuery(query_params)
+
+        request = QNetworkRequest(url)
+        request.setHeader(QNetworkRequest.KnownHeaders.ContentTypeHeader, "application/json")
+
+        # Send POST request
+        self.network_manager.post(request, b"{}")
+
+    def on_request_finished(self, reply: QNetworkReply):
+        # Re-enable button
+        self.submit_btn.setEnabled(True)
+        self.submit_btn.setText("Submit")
+
+        if reply.error() != QNetworkReply.NetworkError.NoError:
+            error_msg = reply.errorString()
+            # Try to read body for more specific error
+            body = reply.readAll().data().decode('utf-8')
+            if body:
+                try:
+                    err_json = json.loads(body)
+                    if "detail" in err_json:
+                        error_msg = err_json["detail"]
+                except Exception:
+                    pass
+            QMessageBox.critical(self, "Error", f"Failed to generate scenario:\n{error_msg}")
+            reply.deleteLater()
+            return
+
+        # Parse JSON response
+        data_bytes = reply.readAll().data()
+        try:
+            data_str = data_bytes.decode('utf-8')
+            data = json.loads(data_str)
+
+            # Format and set Recommendations
+            recs_data = data.get("recommendations", {})
+            recs_html = "<dl>"
+            for key, value in recs_data.items():
+                recs_html += f"<dt style='font-weight: bold;'>{key}</dt><dd>{value}</dd>"
+            recs_html += "</dl>"
+            self.recs_output.setHtml(recs_html)
+
+            # Set Raw Output
+            pretty_json = json.dumps(data, indent=2)
+            self.raw_output.setPlainText(pretty_json)
+
+        except json.JSONDecodeError:
+            QMessageBox.critical(self, "Error", "Failed to parse response from server.")
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"An unexpected error occurred:\n{str(e)}")
+
+        reply.deleteLater()
+
+def main():
+    app = QApplication(sys.argv)
+
+    # Optional: Set an application-wide style or palette
+    app.setStyle("Fusion")
+
+    window = PFunHealthTipsDemo()
+    window.show()
+
+    sys.exit(app.exec())
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,4 +139,5 @@ pfun-common = { path = "./packages/pfun_common" }
 [tool.uv.workspace]
 members = [
     "pfun-gradio",
+    "packages/pfun_qt_gui",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,12 @@
 version = 1
 revision = 3
-requires-python = ">=3.12.11, <3.12.13"
+requires-python = "==3.12.11"
+
+[manifest]
+members = [
+    "pfun-cma-model",
+    "pfun-qt-gui",
+]
 
 [[package]]
 name = "aiofiles"
@@ -1798,6 +1804,21 @@ wheels = [
 ]
 
 [[package]]
+name = "pfun-qt-gui"
+version = "0.1.0"
+source = { editable = "packages/pfun_qt_gui" }
+dependencies = [
+    { name = "pfun-common" },
+    { name = "pyqt6" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pfun-common", directory = "packages/pfun_common" },
+    { name = "pyqt6", specifier = ">=6.6.0" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2069,6 +2090,49 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "pyqt6"
+version = "6.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyqt6-qt6" },
+    { name = "pyqt6-sip" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/03/e756f52e8b0d7bb5527baf8c46d59af0746391943bdb8655acba22ee4168/pyqt6-6.10.2.tar.gz", hash = "sha256:6c0db5d8cbb9a3e7e2b5b51d0ff3f283121fa27b864db6d2f35b663c9be5cc83", size = 1085573, upload-time = "2026-01-08T16:40:00.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/3f/f073a980969aa485ef288eb2e3b94c223ba9c7ac9941543f19b51659b98d/pyqt6-6.10.2-cp39-abi3-macosx_10_14_universal2.whl", hash = "sha256:37ae7c1183fe4dd0c6aefd2006a35731245de1cb6f817bb9e414a3e4848dfd6d", size = 60244482, upload-time = "2026-01-08T16:38:50.837Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/3e/9a015651ec71cea2e2f960c37edeb21623ba96a74956c0827def837f7c6b/pyqt6-6.10.2-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:78e1b3d5763e4cbc84485aef600e0aba5e1932fd263b716f92cd1a40dfa5e924", size = 37899440, upload-time = "2026-01-08T16:39:09.027Z" },
+    { url = "https://files.pythonhosted.org/packages/51/74/a88fec2b99700270ca5d7dc7d650236a4990ed6fc88e055ca0fc8a339ee3/pyqt6-6.10.2-cp39-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:bbc3af541bbecd27301bfe69fe445aa1611a9b490bd3de77306b12df632f7ec6", size = 40748467, upload-time = "2026-01-08T16:39:29.551Z" },
+    { url = "https://files.pythonhosted.org/packages/75/34/be7a55529607b21db00a49ca53cb07c3092d2a5a95ea19bb95cfa0346904/pyqt6-6.10.2-cp39-abi3-win_amd64.whl", hash = "sha256:bd328cb70bc382c48861cd5f0a11b2b8ae6f5692d5a2d6679ba52785dced327b", size = 26015391, upload-time = "2026-01-08T16:39:42.946Z" },
+    { url = "https://files.pythonhosted.org/packages/af/de/d9c88f976602b7884fec4ad54a4575d48e23e4f390e5357ea83917358846/pyqt6-6.10.2-cp39-abi3-win_arm64.whl", hash = "sha256:7901ba1df024b7ee9fdacfb2b7661aeb3749ae8b0bef65428077de3e0450eabb", size = 26208415, upload-time = "2026-01-08T16:39:57.751Z" },
+]
+
+[[package]]
+name = "pyqt6-qt6"
+version = "6.10.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/eb/f04d547d8ed9f20c7b246db4ef5d93b49cab4692009a10652ed0a8b9d2aa/pyqt6_qt6-6.10.2-py3-none-macosx_10_14_x86_64.whl", hash = "sha256:5761cfccc721da2311c3f1213577f0ff1df07bbbbe3fa3a209a256b82cf057e3", size = 68688870, upload-time = "2026-01-29T12:26:48.619Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/c8/d99e65ab01c2402fb6bc4f77abef7244f7d5fb2f2e6d5b0abdf71bb2e4fc/pyqt6_qt6-6.10.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6dda853a8db1b8d1a2ddbbe76cc6c3aa86614cad14056bd3c0435d8feea73b2d", size = 62512013, upload-time = "2026-01-29T12:27:24.642Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fe/01fd9b9d2ca139ef61582f2e2da249fa169229144294c1bb27db59ad8420/pyqt6_qt6-6.10.2-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:19c10b5f0806e9f9bac2c9759bd5d7d19a78967f330fd60a2db409177fa76e49", size = 84028760, upload-time = "2026-01-29T12:28:03.267Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/20/a0d027ebb267d3afaf319d94efe1ff4d667004ee83b96701329a4d11fb95/pyqt6_qt6-6.10.2-py3-none-manylinux_2_39_aarch64.whl", hash = "sha256:2e60d616861ca4565cd295418d605975aa2dc407ba4b94c1586a70c92e9cb052", size = 83063975, upload-time = "2026-01-29T12:28:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8e/595f215876d507417cc8565e05519916d3b0b76baedea6a1e4e5105633fc/pyqt6_qt6-6.10.2-py3-none-win_amd64.whl", hash = "sha256:c4b7f7d66cc58bddf1bc1ca28dfcf7a45f58cfcb11d81d13a0510409dd4957ac", size = 78433821, upload-time = "2026-01-29T12:29:35.493Z" },
+    { url = "https://files.pythonhosted.org/packages/50/5f/2196e2b536217b87cb3d2ce13ef8f7607d08b02f1990a4bd84a88d293a3c/pyqt6_qt6-6.10.2-py3-none-win_arm64.whl", hash = "sha256:7164a6f0c1335358a3026df9865c8f75395b01f60f0dcd2f66c029ec16fc83d2", size = 58354426, upload-time = "2026-01-29T12:30:02.95Z" },
+]
+
+[[package]]
+name = "pyqt6-sip"
+version = "13.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/24/a753e1af94b9ae5b2da63d4598457308da3cdbf0838c959381db086ccc86/pyqt6_sip-13.11.1.tar.gz", hash = "sha256:869c5b48afe38e55b1ee0dd72182b0886e968cc509b98023ff50010b013ce1be", size = 92574, upload-time = "2026-03-09T13:01:35.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/27/47598e701d284497216bf97bf8b6a69f5e61412e716c232ff2b7e6cb2100/pyqt6_sip-13.11.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ba9d362dd1e54b43bc2594f8841e1e39d24789716d28f08e5c9282af9fca342c", size = 112564, upload-time = "2026-03-09T13:01:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/95/cb/116f9b328636765f3bce97d9e10ec041c54bbe92beb0617edb86c2b615c1/pyqt6_sip-13.11.1-cp312-cp312-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0df15849946cea969d3ff2b24b76149262b6044aea2c5403e4f70c24c973a4c8", size = 299564, upload-time = "2026-03-09T13:01:17.292Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/be/fe2321285e8f683e705d199dbb458131f1850dc5966155a19c40100c85bb/pyqt6_sip-13.11.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c52b2b27fc77d9447a8dc1c6de1aaccc22d41e48697aafb2f2f20b8984bb02a5", size = 321210, upload-time = "2026-03-09T13:01:15.904Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9b/7d4b10f9cba1b6f581dfb4860b9d11898da55a5ed3b8a6e7a1bf9f7084d0/pyqt6_sip-13.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:1d1c67179c1924b28e3d7f04585639e7a7c0946f62390efc6ccf2a6206e595d3", size = 53351, upload-time = "2026-03-09T13:01:19.327Z" },
+    { url = "https://files.pythonhosted.org/packages/06/72/6c4e6f21cafa4bed40d2b0c1563525b0d8bfcb5734493696f4cfd043b45f/pyqt6_sip-13.11.1-cp312-cp312-win_arm64.whl", hash = "sha256:d83543125fe9fdb153e7e446c3b4d056d80ab5953644660633ab3f80e7784194", size = 48746, upload-time = "2026-03-09T13:01:20.248Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a native desktop application (PyQt6) that serves as a frontend interface for the PFun CMA Model API, specifically replicating the LLM Scenario Generator Demo. The code relies on standard Qt components for style, layout, and HTTP requests, creating a robust, non-blocking client that does not rely on webviews.

---
*PR created automatically by Jules for task [5522938623191475660](https://jules.google.com/task/5522938623191475660) started by @rocapp*