### PR TITLE
Add pytest configuration for consistent test discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,3 +156,8 @@ pfun-qt-gui = { path = "./packages/pfun_qt_gui"}
 members = [
     "pfun-gradio",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py", "*_test.py"]
+addopts = "--tb=short --durations=5"


### PR DESCRIPTION
- Add [tool.pytest.ini_options] section to pyproject.toml
- Explicitly define testpaths and python_files patterns
- Consolidate pytest options (tb=short, durations=5)
- Improves test file recognition and CI consistency