### PR TITLE
🧹 Refactor: Encapsulate `vectorized_G` parameters into `CMAModelParams`

### DIFF
--- a/pfun_cma_model/engine/calc.py
+++ b/pfun_cma_model/engine/calc.py
@@ -4,14 +4,25 @@ import importlib
 import sys
 from pathlib import Path
 from typing import Literal
-from numpy import array, atleast_1d, clip, cos
+from numpy import array, atleast_1d, clip, cos, broadcast_to
 from numpy import exp as np_exp
 from numpy import (
-    log, nan, ndarray, pi, piecewise, power, zeros,
-    nansum, nanmean, nanmin, nanmax,
+    log,
+    nan,
+    ndarray,
+    pi,
+    piecewise,
+    power,
+    zeros,
+    nansum,
+    nanmean,
+    nanmin,
+    nanmax,
 )
 from pandas import Series
 from pydantic import BaseModel
+from pfun_cma_model.engine.cma_model_params import CMAModelParams
+
 try:
     from pfun_cma_model.misc.decorators import check_is_numpy
 except ModuleNotFoundError:
@@ -90,10 +101,17 @@ GlucoseUnits = Literal["mgdl", "mmoll"]
 
 def guess_glucose_units(values) -> GlucoseUnits:
     """Guess the glucose units (mgdl or mmoll)."""
+
     def calc_dist(x):
         gx0, gx1, gx_s = nanmin(values), nanmax(values), nanmean(values)
         gx = array([gx0, gx1, gx_s])
-        return "mgdl" if nansum((gx - GlucoseRange_mgdl().g_range) ** 2) < nansum((gx - GlucoseRange_mmoll().g_range) ** 2) else "mmoll"
+        return (
+            "mgdl"
+            if nansum((gx - GlucoseRange_mgdl().g_range) ** 2)
+            < nansum((gx - GlucoseRange_mmoll().g_range) ** 2)
+            else "mmoll"
+        )
+
     return calc_dist(values)
 
 
@@ -187,11 +205,7 @@ def K(x: ndarray):
 def vectorized_G(
     t: ndarray | float,
     I_E: ndarray | float,
-    tm: ndarray | float,
-    taug: ndarray | float,
-    B: float,
-    Cm: float,
-    toff: float,
+    params: CMAModelParams,
     include_bias: bool = False,
 ):
     """Vectorized version of G(t, I_E, tm, taug, B, Cm, toff).
@@ -202,25 +216,19 @@ def vectorized_G(
         Time vector (hours).
     I_E : float
         Extracellular insulin (u*mg/mL).
-    tm : array_like
-        Meal times (hours).
-    taug : array_like
-        Meal duration (hours).
-    B : float
-        Bias constant.
-    Cm : float
-        Cortisol temporal sensitivity coefficient (u/h).
-    toff : float
-        Meal-relative time offset (hours).
+    params: CMAModelParams
+        Model parameters.
+    include_bias: bool
+        Whether to include bias.
 
     Returns
     -------
     array_like
         G(t, I_E, tm, taug, B, Cm, toff).
     """
-    tm = atleast_1d(tm)
+    tm = atleast_1d(params.tM)
     t = atleast_1d(t)
-    taug = atleast_1d(taug)
+    taug = broadcast_to(atleast_1d(params.taug), tm.shape)
 
     def Gtmp(tm_: float | ndarray, taug_: float | ndarray):
         k_G = K((t - atleast_1d(tm_)) / power(atleast_1d(taug_), 2))
@@ -235,5 +243,7 @@ def vectorized_G(
         out[j, :] = gtmp
         j = j + 1
     if include_bias:
-        out = out + B * (1.0 + meal_distr(Cm, t, toff))  # ! apply bias constant.
+        out = out + params.B * (
+            1.0 + meal_distr(params.Cm, t, params.toff)
+        )  # ! apply bias constant.
     return out

--- a/pfun_cma_model/engine/cma.py
+++ b/pfun_cma_model/engine/cma.py
@@ -601,16 +601,14 @@ class CMASleepWakeModel:
             # type: ignore
             t,
             self.I_E[-1],
-            self.tM,
-            self.taug,
-            self.B,
-            self.Cm,
-            self.toff,
+            self.params,
         )
         df_gt = DataFrame(
             {"Gt{}".format(i): Gt[i] for i in range(Gt.shape[0])}, index=t
         )  # type: ignore
-        df_gt["Gt"] = nansum(Gt, axis=0) + self.B * (1.0 + meal_distr(self.Cm, t, self.toff))
+        df_gt["Gt"] = nansum(Gt, axis=0) + self.B * (
+            1.0 + meal_distr(self.Cm, t, self.toff)
+        )
         return df_gt
 
     def update_Gt(self, t=None, dt=None, n=1, keep_tvec_size=True):
@@ -640,9 +638,7 @@ class CMASleepWakeModel:
         Returns:
             np.ndarray: Array of Post-prandial glucose dynamics.
         """
-        return vectorized_G(
-            self.t, self.I_E, self.tM, self.taug, self.B, self.Cm, self.toff
-        )  # type: ignore
+        return vectorized_G(self.t, self.I_E, self.params)  # type: ignore
 
     @property
     def g(self):
@@ -745,7 +741,9 @@ class CMASleepWakeModel:
     @property
     def g_instant(self):
         """vector of instantaneous (overall) glucose."""
-        return nansum(self.g, axis=0) + self.B * (1.0 + meal_distr(self.Cm, self.t, self.toff))
+        return nansum(self.g, axis=0) + self.B * (
+            1.0 + meal_distr(self.Cm, self.t, self.toff)
+        )
 
     @property
     def df(self) -> DataFrame:


### PR DESCRIPTION
🎯 **What:** 
The `vectorized_G` function in `pfun_cma_model/engine/calc.py` originally had a long signature expecting many individual model parameters (`tm`, `taug`, `B`, `Cm`, `toff`). This was refactored to encapsulate these parameters into a single `CMAModelParams` Pydantic model. 

💡 **Why:** 
Passing a single configuration object significantly improves code readability and maintainability. It reduces the overhead in caller methods, ensures the types and defaults are consistently managed by the Pydantic schema, and guards against bugs (such as passing arguments out-of-order). It also future-proofs the function if more configuration parameters need to be added. 

✅ **Verification:** 
- The refactored code correctly utilizes `numpy.broadcast_to` to handle cases where `params.taug` is provided as a scalar rather than an array, ensuring `zip(tm, taug)` works correctly. 
- All existing tests pass. 
- Lint checks and formatting were executed (`uv run ruff check` / `uv run ruff format`).

✨ **Result:** 
Cleaner signatures in calculation functions and more concise caller code inside `cma.py` without breaking any existing behavior.

---
*PR created automatically by Jules for task [8124054392086856627](https://jules.google.com/task/8124054392086856627) started by @rocapp*