### PR TITLE
🧪 Add test suite for LLM logic in pfun_cma_model

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,185 @@
+import pfun_path_helper as pph
+
+pph.append_path(path=pph.get_lib_path("pfun_cma_model"))  # noqa: E402
+from . import test_base
+
+test_base.setup_test_environment()
+
+import json
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import pytest
+
+from pfun_cma_model.llm import (
+    generate_scenario,
+    _call_llm_for_json,
+    _parse_generated_response,
+    PFunLLMGeneratedScenario
+)
+
+
+@pytest.mark.asyncio
+class TestGenerateScenario:
+    @patch("pfun_cma_model.llm._call_llm_for_json")
+    async def test_generate_scenario_success(self, mock_call_llm):
+        # Setup mock return value
+        mock_response = {
+            "forecasted_events": "Test event",
+            "qualitative_description": "Test description",
+            "parameters": {
+                "Cm": {"value": 1.5, "stderr": 0.1, "description": "Test Cm"}
+            },
+            "recommendations": {
+                "diet": "Test diet recommendation"
+            }
+        }
+        mock_call_llm.return_value = mock_response
+
+        # Call function
+        result = await generate_scenario(
+            query="Test query",
+            include_recommendations=True
+        )
+
+        # Assertions
+        assert isinstance(result, PFunLLMGeneratedScenario)
+        assert result.forecasted_events == "Test event"
+        assert result.qualitative_description == "Test description"
+        assert "Cm" in result.parameters
+        assert "diet" in result.recommendations
+
+        # Verify call arguments
+        mock_call_llm.assert_called_once()
+        args, kwargs = mock_call_llm.call_args
+        prompt = args[0]
+        assert "User: \"Test query\"" in prompt
+        assert "recommendations" in prompt
+
+    @patch("pfun_cma_model.llm._call_llm_for_json")
+    async def test_generate_scenario_no_recommendations(self, mock_call_llm):
+        mock_response = {
+            "forecasted_events": "Test event",
+            "qualitative_description": "Test description",
+            "parameters": {
+                "Cm": {"value": 1.5, "stderr": 0.1, "description": "Test Cm"}
+            },
+            "recommendations": {}
+        }
+        mock_call_llm.return_value = mock_response
+
+        # Call function
+        result = await generate_scenario(
+            query="Another query",
+            include_recommendations=False
+        )
+
+        # Assertions
+        assert isinstance(result, PFunLLMGeneratedScenario)
+
+        mock_call_llm.assert_called_once()
+        args, kwargs = mock_call_llm.call_args
+        prompt = args[0]
+        assert "User: \"Another query\"" in prompt
+        assert "\"recommendations\":" not in prompt.split("Assistant:")[0] # Make sure recommendations isn't in the prompt schema
+
+    @patch("pfun_cma_model.llm._call_llm_for_json")
+    async def test_generate_scenario_no_query(self, mock_call_llm):
+        mock_response = {
+            "forecasted_events": "Test event",
+            "qualitative_description": "Test description",
+            "parameters": {
+                "Cm": {"value": 1.5, "stderr": 0.1, "description": "Test Cm"}
+            },
+            "recommendations": {}
+        }
+        mock_call_llm.return_value = mock_response
+
+        result = await generate_scenario()
+
+        args, kwargs = mock_call_llm.call_args
+        prompt = args[0]
+        assert "User: \"No query provided.\"" in prompt
+
+    @patch("pfun_cma_model.llm._call_llm_for_json")
+    async def test_generate_scenario_exception_bubbling(self, mock_call_llm):
+        mock_call_llm.side_effect = Exception("API Error")
+
+        with pytest.raises(Exception, match="API Error"):
+            await generate_scenario()
+
+@pytest.mark.asyncio
+class TestCallLLMForJson:
+    @patch("pfun_cma_model.llm.GenerativeModel")
+    @patch("pfun_cma_model.llm._parse_generated_response")
+    async def test_call_llm_for_json_markdown_block(self, mock_parse, mock_gen_model):
+        mock_model_instance = MagicMock()
+        mock_gen_model.return_value = mock_model_instance
+
+        # Markdown JSON response
+        json_data = {"key": "value"}
+        mock_parse.return_value = f"Some text here\n```json\n{json.dumps(json_data)}\n```\nMore text"
+
+        result = await _call_llm_for_json("test prompt")
+        assert result == json_data
+
+    @patch("pfun_cma_model.llm.GenerativeModel")
+    @patch("pfun_cma_model.llm._parse_generated_response")
+    async def test_call_llm_for_json_no_markdown(self, mock_parse, mock_gen_model):
+        mock_model_instance = MagicMock()
+        mock_gen_model.return_value = mock_model_instance
+
+        # Raw JSON response
+        json_data = {"key": "value", "nested": {"test": 123}}
+        mock_parse.return_value = f"   {json.dumps(json_data)}   "
+
+        result = await _call_llm_for_json("test prompt")
+        assert result == json_data
+
+    @patch("pfun_cma_model.llm.GenerativeModel")
+    @patch("pfun_cma_model.llm._parse_generated_response")
+    async def test_call_llm_for_json_invalid_json(self, mock_parse, mock_gen_model):
+        mock_model_instance = MagicMock()
+        mock_gen_model.return_value = mock_model_instance
+
+        mock_parse.return_value = "```json\n{invalid json}\n```"
+
+        with pytest.raises(Exception, match="Failed to parse LLM API response"):
+            await _call_llm_for_json("test prompt")
+
+
+@pytest.mark.asyncio
+class TestParseGeneratedResponse:
+    async def test_parse_generated_response_sync(self):
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "message": {"content": "Hello World"}
+        }
+        # Deliberately remove __await__ to simulate sync object
+        del mock_response.__await__
+
+        result = await _parse_generated_response(mock_response)
+        assert result == "Hello World"
+
+    async def test_parse_generated_response_async(self):
+        mock_sync_response = MagicMock()
+        mock_sync_response.model_dump.return_value = {
+            "message": {"content": "Async Hello"}
+        }
+        del mock_sync_response.__await__
+
+        async def mock_async_call():
+            return mock_sync_response
+
+        # mock_async_call() is an awaitable (coroutine)
+        result = await _parse_generated_response(mock_async_call())
+        assert result == "Async Hello"
+
+    async def test_parse_generated_response_unicode_handling(self):
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "message": {"content": "Unicode text '"}
+        }
+        del mock_response.__await__
+
+        result = await _parse_generated_response(mock_response)
+        assert result == 'Unicode text "'


### PR DESCRIPTION
* 🎯 **What:** The testing gap addressed: Missing test coverage for `pfun_cma_model/llm.py`, particularly the `generate_scenario` function which lacked isolated tests for its async behavior and LLM calling mechanisms.
* 📊 **Coverage:** What scenarios are now tested: `generate_scenario` with and without recommendations/queries, Exception bubbling in LLM call, Markdown vs raw JSON decoding logic inside `_call_llm_for_json`, and both synchronous/asynchronous logic branches and Unicode decoding inside `_parse_generated_response`.
* ✨ **Result:** The improvement in test coverage: Improved overall robustness and reliability of LLM generation logic ensuring correct structure and formatting of queries before hitting generation endpoint.

---
*PR created automatically by Jules for task [17640396160706681839](https://jules.google.com/task/17640396160706681839) started by @rocapp*